### PR TITLE
Run hobart test workflow every 5 minutes

### DIFF
--- a/.github/workflows/hobart_5pm_test.yml
+++ b/.github/workflows/hobart_5pm_test.yml
@@ -1,10 +1,9 @@
 name: Hansard every 5 minutes
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '*/5 * * * *'     # GitHub Actions minimum granularity
-  # optional manual trigger for debugging:
-  workflow_dispatch: {}
+    - cron: '*/5 * * * *' # Run every five minutes indefinitely
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- ensure workflow `hobart_5pm_test.yml` is scheduled using `*/5 * * * *`
- reorder triggers to include manual dispatch and add note that schedule runs indefinitely

## Testing
- `yamllint .github/workflows/hobart_5pm_test.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68a820fdfbc4833285b7054dad13432b