### PR TITLE
Add email digest step to scan workflow

### DIFF
--- a/.github/workflows/scan_new.yml
+++ b/.github/workflows/scan_new.yml
@@ -46,16 +46,12 @@ jobs:
           git add transcripts/*.txt || echo "No transcripts"
           git commit -m "New transcripts (auto)" || echo "No changes"
           git push
+      - name: Install email deps
+        run: python -m pip install yagmail python-dateutil
 
-      # OPTIONAL: if you want to email after downloads, keep your existing send step here
-      # - name: Install email deps
-      #   run: python -m pip install yagmail python-dateutil
-      # - name: Send keyword digest email
-      #   env:
-      #     EMAIL_USER: ${{ secrets.EMAIL_USER }}
-      #     EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
-      #     EMAIL_TO:   ${{ secrets.EMAIL_TO }}
-      #     SMTP_HOST:  ${{ secrets.SMTP_HOST }}
-      #     SMTP_PORT:  ${{ secrets.SMTP_PORT }}
-      #     KEYWORDS:   ${{ vars.KEYWORDS }}   # or use a keywords.txt file, per your current script
-      #   run: python send_email.py
+      - name: Send keyword digest email
+        env:
+          EMAIL_USER: ${{ secrets.EMAIL_USER }}
+          EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+          EMAIL_TO:   ${{ secrets.EMAIL_TO }}
+        run: python send_email.py


### PR DESCRIPTION
## Summary
- send keyword digest email after committing new transcripts

## Testing
- `python -m py_compile send_email.py scan_new_transcripts.py`


------
https://chatgpt.com/codex/tasks/task_e_68abf670fcd88332b9b9a2ccf9d08b00