### PR TITLE
Prevent re-sending previously emailed transcripts

### DIFF
--- a/.github/workflows/scan_new.yml
+++ b/.github/workflows/scan_new.yml
@@ -52,3 +52,11 @@ jobs:
           EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
           EMAIL_TO:   ${{ secrets.EMAIL_TO }}
         run: python send_email.py
+
+      - name: Commit sent log
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add sent.log || echo "No log"
+          git commit -m "Update sent log (auto)" || echo "No changes"
+          git push

--- a/send_email.py
+++ b/send_email.py
@@ -1,14 +1,20 @@
 import os
 import re
 import glob
-import yagmail
 from pathlib import Path
 from datetime import datetime
 
-# --- Helpers ---
+import yagmail
+
+
+# File that records which transcripts have already been emailed
+LOG_FILE = Path("sent.log")
+
+
+# --- Helpers -----------------------------------------------------------------
 
 def load_keywords():
-    """Load keywords from keywords.txt or KEYWORDS env var"""
+    """Load keywords from keywords.txt or KEYWORDS env var."""
     if os.path.exists("keywords.txt"):
         with open("keywords.txt", encoding="utf-8") as f:
             return [kw.strip() for kw in f if kw.strip()]
@@ -17,12 +23,12 @@ def load_keywords():
     return []
 
 
-def split_paragraphs(text):
+def split_paragraphs(text: str):
     """Split transcript into paragraphs."""
     return re.split(r"\n\s*\n", text)
 
 
-def detect_speaker(paragraph):
+def detect_speaker(paragraph: str):
     """Detect speaker name at start of paragraph."""
     first_line = paragraph.strip().split("\n", 1)[0]
     if re.match(r"^(Mr|Ms|Mrs|Hon|Premier)\b", first_line):
@@ -30,7 +36,7 @@ def detect_speaker(paragraph):
     return None
 
 
-def extract_matches(text, keywords):
+def extract_matches(text: str, keywords):
     """Find keyword matches and return structured results."""
     results = []
     paragraphs = split_paragraphs(text)
@@ -51,8 +57,8 @@ def extract_matches(text, keywords):
     return results
 
 
-def parse_date_from_filename(filename):
-    """Extract datetime from Hansard filename, e.g. House_of_Assembly_Tuesday_3_June_2025.txt"""
+def parse_date_from_filename(filename: str):
+    """Extract datetime from Hansard filename."""
     m = re.search(r"(\d{1,2} \w+ \d{4})", filename)
     if m:
         try:
@@ -64,7 +70,6 @@ def parse_date_from_filename(filename):
 
 def build_digest(files, keywords):
     """Build the digest body text for email."""
-    all_matches = []
     body_lines = []
 
     # Header
@@ -100,20 +105,40 @@ def build_digest(files, keywords):
     return "\n".join(body_lines), total_matches
 
 
-# --- Main ---
+def load_sent_log():
+    """Return set of transcript filenames that have already been emailed."""
+    if LOG_FILE.exists():
+        return {line.strip() for line in LOG_FILE.read_text().splitlines() if line.strip()}
+    return set()
+
+
+def update_sent_log(files):
+    """Append newly emailed filenames to the log."""
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        for file in files:
+            f.write(f"{Path(file).name}\n")
+
+
+# --- Main --------------------------------------------------------------------
 
 def main():
     EMAIL_USER = os.environ["EMAIL_USER"]
     EMAIL_PASS = os.environ["EMAIL_PASS"]
-    EMAIL_TO   = os.environ["EMAIL_TO"]
+    EMAIL_TO = os.environ["EMAIL_TO"]
 
     keywords = load_keywords()
     if not keywords:
         raise SystemExit("No keywords found (keywords.txt or KEYWORDS env var).")
 
-    files = sorted(glob.glob("transcripts/*.txt"))
-    if not files:
+    all_files = sorted(glob.glob("transcripts/*.txt"))
+    if not all_files:
         raise SystemExit("No transcripts found in transcripts/")
+
+    sent = load_sent_log()
+    files = [f for f in all_files if Path(f).name not in sent]
+    if not files:
+        print("No new transcripts to email.")
+        return
 
     body, total_hits = build_digest(files, keywords)
 
@@ -135,108 +160,14 @@ def main():
         contents=body,
         attachments=files,
     )
-    print(f"✅ Email sent to {EMAIL_TO} with {len(files)} file(s), {total_hits} match(es).")
+
+    update_sent_log(files)
+
+    print(
+        f"✅ Email sent to {EMAIL_TO} with {len(files)} file(s), {total_hits} match(es)."
+    )
 
 
 if __name__ == "__main__":
     main()
-import os
-import re
-import glob
-import yagmail
-from pathlib import Path
-from datetime import datetime
 
-# --- Helpers ---
-
-def load_keywords():
-    """Load keywords from keywords.txt or KEYWORDS env var"""
-    if os.path.exists("keywords.txt"):
-        with open("keywords.txt", encoding="utf-8") as f:
-            return [kw.strip() for kw in f if kw.strip()]
-    if "KEYWORDS" in os.environ:
-        return [kw.strip() for kw in os.environ["KEYWORDS"].split(",") if kw.strip()]
-    return []
-
-
-def split_paragraphs(text):
-    """Split transcript into paragraphs."""
-    return re.split(r"\n\s*\n", text)
-
-
-def detect_speaker(paragraph):
-    """Detect speaker name at start of paragraph."""
-    first_line = paragraph.strip().split("\n", 1)[0]
-    if re.match(r"^(Mr|Ms|Mrs|Hon|Premier)\b", first_line):
-        return first_line.strip()
-    return None
-
-
-def extract_matches(text, keywords):
-    """Find keyword matches and return structured results."""
-    results = []
-    paragraphs = split_paragraphs(text)
-
-    for para in paragraphs:
-        for kw in keywords:
-            if re.search(rf"\b{re.escape(kw)}\b", para, re.IGNORECASE):
-                # Extract 2–3 sentences around keyword
-                sentences = re.split(r"(?<=[.!?])\s+", para.strip())
-                for i, s in enumerate(sentences):
-                    if kw.lower() in s.lower():
-                        start = max(0, i - 1)
-                        end = min(len(sentences), i + 2)
-                        snippet = " ".join(sentences[start:end])
-                        speaker = detect_speaker(para)
-                        results.append((kw, snippet.strip(), speaker))
-                        break
-    return results
-
-
-def parse_date_from_filename(filename):
-    """Extract datetime from Hansard filename, e.g. House_of_Assembly_Tuesday_3_June_2025.txt"""
-    m = re.search(r"(\d{1,2} \w+ \d{4})", filename)
-    if m:
-        try:
-            return datetime.strptime(m.group(1), "%d %B %Y")
-        except ValueError:
-            return datetime.min
-    return datetime.min
-
-
-def build_digest(files, keywords):
-    """Build the digest body text for email."""
-    all_matches = []
-    body_lines = []
-
-    # Header
-    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
-    body_lines.append(f"Time: {now}")
-    body_lines.append("Keywords: " + ", ".join(keywords))
-
-    # Process each transcript file
-    total_matches = 0
-    for f in sorted(files, key=lambda x: parse_date_from_filename(Path(x).name)):
-        text = Path(f).read_text(encoding="utf-8", errors="ignore")
-        matches = extract_matches(text, keywords)
-        if not matches:
-            continue
-        total_matches += len(matches)
-
-        body_lines.append(f"\n=== {Path(f).name} ===")
-        for i, (kw, snippet, speaker) in enumerate(matches, 1):
-            if speaker:
-                body_lines.append(f"🔹 Match #{i} ({speaker})")
-            else:
-                body_lines.append(f"🔹 Match #{i}")
-            body_lines.append(snippet)
-            body_lines.append("")
-
-    body_lines.insert(2, f"Matches found: {total_matches}\n")
-
-    if total_matches == 0:
-        body_lines.append("\n(No keyword matches found.)")
-    else:
-        body_lines.append("(Full transcript(s) attached.)")
-
-    return "\n".join(body_lines), total_matches


### PR DESCRIPTION
## Summary
- Track which transcripts have already been emailed and skip them on subsequent runs
- Commit the sent log after sending emails so history persists across workflows

## Testing
- `python -m py_compile scan_new_transcripts.py send_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf6d4954c833282ce01920dc04f95