### PR TITLE
Remove House prefix filter from transcript downloader

### DIFF
--- a/scan_new_transcripts.py
+++ b/scan_new_transcripts.py
@@ -6,7 +6,6 @@ transcripts not yet in transcripts/ as .txt via the viewer's "As Text" option.
 Environment (optional):
   WAIT_BEFORE_DOWNLOAD_SECONDS   default "15"
   MAX_PAGES                      default "5"
-  HOUSE_PREFIX                   e.g. "House of Assembly" to filter titles
 """
 
 import os
@@ -24,7 +23,6 @@ OUT_DIR.mkdir(parents=True, exist_ok=True)
 
 WAIT_BEFORE_DOWNLOAD = int(os.environ.get("WAIT_BEFORE_DOWNLOAD_SECONDS", "15"))
 MAX_PAGES = int(os.environ.get("MAX_PAGES", "5"))
-HOUSE_PREFIX = os.environ.get("HOUSE_PREFIX", "").strip()  # e.g. "House of Assembly"
 
 HOBART_TZ = ZoneInfo("Australia/Hobart")
 
@@ -71,9 +69,6 @@ def download_current_year_new():
             for i in range(count):
                 link = result_links.nth(i)
                 title = link.inner_text().strip()
-
-                if HOUSE_PREFIX and not title.startswith(HOUSE_PREFIX):
-                    continue
 
                 out_path = OUT_DIR / sanitise_filename(title)
                 if out_path.exists():


### PR DESCRIPTION
## Summary
- Always download all search results regardless of title prefix
- Drop `HOUSE_PREFIX` environment variable and related logic

## Testing
- `python -m py_compile scan_new_transcripts.py`
- `python -m py_compile send_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf9c58fa483328247314d6b3caa7e