### PR TITLE
Handle stand-alone speaker lines in transcripts

### DIFF
--- a/send_email.py
+++ b/send_email.py
@@ -13,7 +13,7 @@ LOG_FILE = Path("sent.log")
 # Regexes for speaker detection and headings
 SPEAKER_RE = re.compile(
     r"^((?:The\s+)?(?:Mr|Ms|Mrs|Dr|Hon|Sir|Madam|Premier|Treasurer|Attorney-General|Leader)\s+"
-    r"[A-Z][A-Za-z’'\-]+(?:\s+[A-Z][A-Za-z’'\-]+)*(?:\s*\([^)]+\))?)\s*-\s",
+    r"[A-Z][A-Za-z’'\-]+(?:\s+[A-Z][A-Za-z’'\-]+)*(?:\s*\([^)]+\))?)\s*-\s*",
 )
 HEADING_RE = re.compile(r"^[A-Z0-9 ,’'()\-.:]{6,}$")
 

--- a/tests/test_extract_matches.py
+++ b/tests/test_extract_matches.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import send_email
+
+
+def test_standalone_speaker_line_inheritance():
+    text = (
+        "Mr John Doe -\n\n"
+        "Apple is tasty.\n\n"
+        "Banana is yellow."
+    )
+    keywords = ["Apple", "Banana"]
+    matches = send_email.extract_matches(text, keywords)
+    assert len(matches) == 2
+    assert [m[2] for m in matches] == ["Mr John Doe -", "Mr John Doe -"]


### PR DESCRIPTION
## Summary
- allow speaker regex to match lines ending immediately after the dash
- ensure paragraphs following a stand-alone speaker line inherit the speaker
- add regression test for speaker line inheritance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad3578137083329be9e2f42cd9ce5f